### PR TITLE
Set blackjack slash command default permissions to everyone

### DIFF
--- a/index.js
+++ b/index.js
@@ -1470,7 +1470,9 @@ client.once('ready', async () => {
         {
             name: 'blackjack',
             description: 'Play blackjack against the dealer',
-            default_member_permissions: null,
+            // Explicitly set default permissions to "0" (everyone) to override any
+            // previously cached admin-only settings for this command.
+            default_member_permissions: '0',
             dm_permission: false,
             options: [ { name: 'amount', description: 'Bet amount (>=1)', type: 4, required: true } ]
         },


### PR DESCRIPTION
## Summary
- ensure the `/blackjack` command registers with default permissions that allow everyone to use it by setting the bitfield to `"0"`

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5393de190832b9cd05c58022a29f3